### PR TITLE
Create React app with Material UI form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+
+# build outputs
+/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# react
+# Material UI Form App
+
+Esta aplicación de ejemplo en React muestra un formulario con un elemento de cada tipo de entrada usando Material UI.
+
+## Scripts
+
+- `npm run dev` – inicia el servidor de desarrollo.
+- `npm test` – ejecuta las pruebas (actualmente sólo muestra un mensaje).
+
+Instala las dependencias con:
+
+```
+npm install
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Formulario Material UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "material-form-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.14.17",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import {
+  Box,
+  TextField,
+  Checkbox,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+  FormControl,
+  FormLabel,
+  Select,
+  MenuItem,
+  InputLabel,
+  Switch,
+  Slider,
+  Button
+} from '@mui/material';
+
+function App() {
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log(Object.fromEntries(data.entries()));
+  };
+
+  return (
+    <Box component="form" sx={{ m: 2 }} onSubmit={handleSubmit}>
+      <TextField label="Texto" name="text" fullWidth margin="normal" />
+      <TextField label="Contraseña" type="password" name="password" fullWidth margin="normal" />
+      <TextField label="Email" type="email" name="email" fullWidth margin="normal" />
+      <TextField label="Número" type="number" name="number" fullWidth margin="normal" />
+      <TextField label="Teléfono" type="tel" name="tel" fullWidth margin="normal" />
+      <TextField label="Fecha" type="date" name="date" fullWidth margin="normal" InputLabelProps={{ shrink: true }} />
+      <TextField label="Hora" type="time" name="time" fullWidth margin="normal" InputLabelProps={{ shrink: true }} />
+      <TextField label="Color" type="color" name="color" fullWidth margin="normal" InputLabelProps={{ shrink: true }} />
+
+      <FormControlLabel control={<Checkbox name="checkbox" />} label="Acepto" />
+
+      <FormControl sx={{ mt: 2 }}>
+        <FormLabel>Género</FormLabel>
+        <RadioGroup row name="gender">
+          <FormControlLabel value="male" control={<Radio />} label="Masculino" />
+          <FormControlLabel value="female" control={<Radio />} label="Femenino" />
+        </RadioGroup>
+      </FormControl>
+
+      <FormControl fullWidth margin="normal">
+        <InputLabel id="select-label">País</InputLabel>
+        <Select labelId="select-label" label="País" name="country" defaultValue="">
+          <MenuItem value="es">España</MenuItem>
+          <MenuItem value="mx">México</MenuItem>
+          <MenuItem value="ar">Argentina</MenuItem>
+        </Select>
+      </FormControl>
+
+      <FormControlLabel control={<Switch name="switch" />} label="Activado" />
+
+      <Box sx={{ width: 300, mt: 2 }}>
+        <Slider defaultValue={30} name="slider" />
+      </Box>
+
+      <Button variant="contained" component="label" sx={{ mt: 2 }}>
+        Subir archivo
+        <input hidden type="file" name="file" />
+      </Button>
+
+      <Button type="submit" variant="contained" sx={{ mt: 2 }}>
+        Enviar
+      </Button>
+    </Box>
+  );
+}
+
+export default App;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import CssBaseline from '@mui/material/CssBaseline';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <CssBaseline />
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add React application scaffold with Vite
- implement form demonstrating diverse Material UI inputs
- document usage and scripts in README

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bccd5d0ec8322bb6710a844fdc428