### PR TITLE
Set up Vitest and add form tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"No tests specified\""
+    "test": "vitest"
   },
   "dependencies": {
     "@emotion/react": "^11.11.1",
@@ -18,6 +18,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^14.0.0",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import App from './App';
+import { vi } from 'vitest';
+
+describe('App form', () => {
+  test('renders all form fields', () => {
+    render(<App />);
+    expect(screen.getByLabelText(/texto/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/contraseña/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/número/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/teléfono/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/fecha/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/hora/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/color/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/acepto/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/masculino/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/femenino/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/país/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/activado/i)).toBeInTheDocument();
+    expect(screen.getByRole('slider')).toBeInTheDocument();
+    expect(screen.getByText(/subir archivo/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /enviar/i })).toBeInTheDocument();
+  });
+
+  test('allows typing and submitting', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    render(<App />);
+    fireEvent.change(screen.getByLabelText(/texto/i), { target: { value: 'hola' } });
+    fireEvent.submit(screen.getByRole('button', { name: /enviar/i }).closest('form'));
+    expect(logSpy).toHaveBeenCalledWith(expect.objectContaining({ text: 'hola' }));
+    logSpy.mockRestore();
+  });
+
+  test('collects submitted values', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    render(<App />);
+    fireEvent.change(screen.getByLabelText(/texto/i), { target: { value: 'abc' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@b.com' } });
+    fireEvent.click(screen.getByLabelText(/acepto/i));
+    fireEvent.click(screen.getByLabelText(/femenino/i));
+    fireEvent.change(screen.getByLabelText(/país/i), { target: { value: 'es' } });
+    fireEvent.click(screen.getByRole('button', { name: /enviar/i }));
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'abc',
+        email: 'a@b.com',
+        checkbox: 'on',
+        gender: 'female',
+        country: 'es',
+      })
+    );
+    logSpy.mockRestore();
+  });
+});
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
 });


### PR DESCRIPTION
## Summary
- add testing libraries and vitest script
- configure Vitest with jsdom environment
- add form rendering and submission tests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c3be02220832294ca7882be738a16