### PR TITLE
feat: add dependent country and province selects

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Container,
   Paper,
@@ -20,12 +20,27 @@ import {
 } from '@mui/material';
 
 function App() {
+  const [country, setCountry] = useState('');
+  const [province, setProvince] = useState('');
+
+  const provincesByCountry = {
+    es: ['Madrid', 'Barcelona', 'Sevilla'],
+    mx: ['Ciudad de México', 'Jalisco', 'Nuevo León'],
+    ar: ['Buenos Aires', 'Córdoba', 'Santa Fe'],
+  };
+
+  const handleCountryChange = (event) => {
+    const value = event.target.value;
+    setCountry(value);
+    setProvince('');
+  };
+
   const handleSubmit = (event) => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
     const values = Object.fromEntries(data.entries());
     localStorage.setItem('formData', JSON.stringify(values));
-    console.log('Datos guardados en Local Storage', values);
+    console.log(values);
   };
 
   return (
@@ -55,11 +70,35 @@ function App() {
       </FormControl>
 
       <FormControl fullWidth margin="normal">
-        <InputLabel id="select-label">País</InputLabel>
-        <Select labelId="select-label" label="País" name="country" defaultValue="">
+        <InputLabel id="select-country-label">País</InputLabel>
+        <Select
+          labelId="select-country-label"
+          label="País"
+          name="country"
+          value={country}
+          onChange={handleCountryChange}
+        >
           <MenuItem value="es">España</MenuItem>
           <MenuItem value="mx">México</MenuItem>
           <MenuItem value="ar">Argentina</MenuItem>
+        </Select>
+      </FormControl>
+
+      <FormControl fullWidth margin="normal" disabled={!country}>
+        <InputLabel id="select-province-label">Provincia</InputLabel>
+        <Select
+          labelId="select-province-label"
+          label="Provincia"
+          name="province"
+          value={province}
+          onChange={(e) => setProvince(e.target.value)}
+        >
+          {country &&
+            provincesByCountry[country].map((p) => (
+              <MenuItem key={p} value={p}>
+                {p}
+              </MenuItem>
+            ))}
         </Select>
       </FormControl>
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -18,6 +18,7 @@ describe('App form', () => {
     expect(screen.getByLabelText(/masculino/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/femenino/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/país/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/provincia/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/activado/i)).toBeInTheDocument();
     expect(screen.getByRole('slider')).toBeInTheDocument();
     expect(screen.getByText(/subir archivo/i)).toBeInTheDocument();
@@ -41,6 +42,7 @@ describe('App form', () => {
     fireEvent.click(screen.getByLabelText(/acepto/i));
     fireEvent.click(screen.getByLabelText(/femenino/i));
     fireEvent.change(screen.getByLabelText(/país/i), { target: { value: 'es' } });
+    fireEvent.change(screen.getByLabelText(/provincia/i), { target: { value: 'Madrid' } });
     fireEvent.click(screen.getByRole('button', { name: /enviar/i }));
     expect(logSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -49,6 +51,7 @@ describe('App form', () => {
         checkbox: 'on',
         gender: 'female',
         country: 'es',
+        province: 'Madrid',
       })
     );
     logSpy.mockRestore();


### PR DESCRIPTION
## Summary
- add country and province select fields with dynamic province options
- track selections with React state
- expand form tests for new dependent province field

## Testing
- `npm test` *(fails: Cannot find dependency 'jsdom')*


------
https://chatgpt.com/codex/tasks/task_e_689cfda088d883229f80d75c9172c6b5